### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@
 
 This repo contains the source code for the cross-platform [.NET Core](http://github.com/dotnet/core) SDK. It aggregates the .NET Toolchain, the .NET Core runtime, the templates, and the .NET Core Windows Desktop runtime. It produces zip, tarballs, and native packages for various supported platforms.
 
-Looking for V2 of the .NET Core tooling?
+Looking for released versions of the .NET Core tooling?
 ----------------------------------------
 
-Download v2.0 of the .NET Core tools (CLI, MSBuild and the new csproj) at https://dot.net/core.
-
-> **Note:** The master branch of the .NET Core SDK repo is based on a forthcoming version of the SDK and is pre-release. For production-level usage, use the
-> released version of the tools available at https://dot.net/core
+Download released versions of the .NET Core tools (CLI, MSBuild and the new csproj) at https://dot.net/core.
 
 Found an issue?
 ---------------


### PR DESCRIPTION
Remove mention of 2.0

@dplaisted I assume this refers to the out of support version? 

Or should it go to https://github.com/dotnet/installer/blob/master/Downloads2.x.md?